### PR TITLE
[Feat] 네이버 로그인 구현 및 유저 정보 저장 및 리뷰 탭 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  swcMinify: true,
   experimental: {
     appDir: true,
   },

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   experimental: {
     appDir: true,
   },
-}
+  images: {
+    domains: ["k.kakaocdn.net"],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const nextConfig = {
     appDir: true,
   },
   images: {
-    domains: ["k.kakaocdn.net"],
+    domains: ["k.kakaocdn.net", "phinf.pstatic.net"],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18.2.0",
         "react-kakao-maps-sdk": "^1.1.9",
         "recoil": "^0.7.7",
+        "recoil-persist": "^4.2.0",
         "sweetalert2": "^11.7.5",
         "swiper": "^9.3.2",
         "tailwindcss": "3.3.2",
@@ -4772,6 +4773,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9114,6 +9123,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "requires": {}
     },
     "redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^18.2.0",
     "react-kakao-maps-sdk": "^1.1.9",
     "recoil": "^0.7.7",
+    "recoil-persist": "^4.2.0",
     "sweetalert2": "^11.7.5",
     "swiper": "^9.3.2",
     "tailwindcss": "3.3.2",

--- a/src/app/oauth/naver/page.tsx
+++ b/src/app/oauth/naver/page.tsx
@@ -1,16 +1,16 @@
 "use client";
-import { KAKAO_TOKEN_URL } from "@/components/login/Oauth";
-import { kakaoTokenAtom, userAtom } from "@/state";
+import { NAVER_TOKEN_URL } from "@/components/login/Oauth";
+import { naverTokenAtom, userAtom } from "@/state";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 
-export default function KakaoLoginHandler() {
+export default function NaverLoginHandler() {
   const router = useRouter();
 
-  const [kakaoToken, setKakaoToken] = useRecoilState(kakaoTokenAtom);
+  const [naverToken, setNaverToken] = useRecoilState(naverTokenAtom);
 
   // redirect_uri로 받은 code를 이용하여 access_token을 받아옵니다.
   const searchParams = useSearchParams();
@@ -19,45 +19,45 @@ export default function KakaoLoginHandler() {
   // TokenAtom에 access_token을 저장하기 위해 recoil을 사용합니다.
   const setAccessToken = useSetRecoilState(userAtom);
 
-  const kakaoTokenLink = `${KAKAO_TOKEN_URL}${code}`;
+  const naverTokenLink = `${NAVER_TOKEN_URL}${code}`;
 
-  //1. 인가코드 보내서 토큰 받기(from Kakao)
-  const getKakaoToken = async () => {
-    return await axios.post(kakaoTokenLink, {
+  //1. 인가코드 보내서 토큰 받기(from Naver)
+  const getNaverToken = async () => {
+    return await axios.post(naverTokenLink, {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       maxRedirects: 0,
     });
   };
 
   const {
-    mutate: getKakaoTokenMutate,
-    isLoading: kakaoTokenIsLoding,
-    isError: kakaoTokenIsError,
-  } = useMutation(["getKakaoToken"], getKakaoToken, {
-    onSuccess: (kakao) => {
+    mutate: getNaverTokenMutate,
+    isLoading: naverTokenIsLoding,
+    isError: naverTokenIsError,
+  } = useMutation(["getNaverToken"], getNaverToken, {
+    onSuccess: (naver) => {
       // access_token을 받아온 후 임시 저장합니다.
-      setKakaoToken(kakao.data.access_token);
-      getKakaoUserInfoMutate();
+      setNaverToken(naver.data.access_token);
+      getNaverUserInfoMutate();
     },
   });
 
   //2. 토큰 보내서 사용자 정보 받기(from Backend)
-  const getKakaoUserInfo = async () => {
+  const getNaverUserInfo = async () => {
     return await axios.post(
       `${process.env.NEXT_PUBLIC_API_URL}/api/v1/accounts/oauth/login`,
       {
-        socialType: "Kakao",
-        accessToken: kakaoToken,
+        socialType: "Naver",
+        accessToken: naverToken,
       }
     );
   };
 
   const {
-    mutate: getKakaoUserInfoMutate,
-    data: kakaoUserInfo,
-    isLoading: kakaoUserInfoIsLoding,
-    isError: kakaoUserInfoIsError,
-  } = useMutation(["getKakaoUserInfo"], getKakaoUserInfo, {
+    mutate: getNaverUserInfoMutate,
+    data: NaverUserInfo,
+    isLoading: naverUserInfoIsLoding,
+    isError: naverUserInfoIsError,
+  } = useMutation(["getNaverUserInfo"], getNaverUserInfo, {
     onSuccess: (res) => {
       setAccessToken(res.data);
       router.replace("/");
@@ -65,15 +65,15 @@ export default function KakaoLoginHandler() {
   });
 
   useEffect(() => {
-    getKakaoTokenMutate();
+    getNaverTokenMutate();
   }, []);
 
-  if (kakaoTokenIsError || kakaoUserInfoIsError) {
+  if (naverTokenIsError || naverUserInfoIsError) {
     alert("오류가 발생했습니다. 다시 로그인 해주세요");
     router.push("/login");
   }
 
-  if (kakaoTokenIsLoding || kakaoUserInfoIsLoding) {
+  if (naverTokenIsLoding || naverUserInfoIsLoding) {
     return (
       <div className="flex h-screen justify-center items-center">
         <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 import Logo from "./Logo";
 import Link from "next/link";
 import { useRecoilValue } from "recoil";
-import { TokenAtom, isLoginSelector } from "@/state";
+import { isLoginSelector } from "@/state";
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/src/components/detail/DetailFrame.tsx
+++ b/src/components/detail/DetailFrame.tsx
@@ -3,9 +3,9 @@ import KakaoMap from "./KakaoMap";
 import { useQuery } from "@tanstack/react-query";
 import ContentCard from "./ContentCard";
 import { Tab } from "@headlessui/react";
-import { useState } from "react";
 import { useParams, usePathname } from "next/navigation";
 import axios from "axios";
+import Review from "./Review";
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
@@ -29,41 +29,6 @@ export default function DetailFrame() {
     }
   };
 
-  let [categories] = useState({
-    좋아요: [
-      {
-        id: 1,
-        title: "Does drinking coffee make you smarter?",
-        date: "5h ago",
-        commentCount: 5,
-        shareCount: 2,
-      },
-      {
-        id: 2,
-        title: "So you've bought coffee... now what?",
-        date: "2h ago",
-        commentCount: 3,
-        shareCount: 2,
-      },
-    ],
-    "내가 작성한 리뷰": [
-      {
-        id: 1,
-        title:
-          "Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?Is tech making coffee better or worse?",
-        date: "Jan 7",
-        commentCount: 29,
-        shareCount: 16,
-      },
-      {
-        id: 2,
-        title: "The most innovative things happening in coffee",
-        date: "Mar 19",
-        commentCount: 24,
-        shareCount: 12,
-      },
-    ],
-  });
   const { isLoading, isError, data, error } = useQuery(
     ["detail"],
     getDetailData,
@@ -208,34 +173,7 @@ export default function DetailFrame() {
                 </div>
               </Tab.Panel>
               <Tab.Panel className={classNames("rounded-xl bg-white p-3")}>
-                <ul>
-                  {categories["내가 작성한 리뷰"].map((post) => (
-                    <li
-                      key={post.id}
-                      className="relative rounded-md p-3 hover:bg-gray-100"
-                    >
-                      <h3 className="text-sm font-medium leading-5 truncate">
-                        {post.title}
-                      </h3>
-
-                      <ul className="mt-1 flex space-x-1 text-xs font-normal leading-4 text-gray-500">
-                        <li>{post.date}</li>
-                        <li>&middot;</li>
-                        <li>{post.commentCount} comments</li>
-                        <li>&middot;</li>
-                        <li>{post.shareCount} shares</li>
-                      </ul>
-
-                      <a
-                        href="#"
-                        className={classNames(
-                          "absolute inset-0 rounded-md",
-                          "ring-yellow-400 focus:z-10 focus:outline-none focus:ring-2"
-                        )}
-                      />
-                    </li>
-                  ))}
-                </ul>
+                <Review />
               </Tab.Panel>
             </Tab.Panels>
           </Tab.Group>

--- a/src/components/detail/Review.tsx
+++ b/src/components/detail/Review.tsx
@@ -1,0 +1,398 @@
+import { Menu, Transition } from "@headlessui/react";
+import { Fragment, useEffect, useRef, useState } from "react";
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
+
+export default function Review() {
+  return (
+    <section className="bg-white py-8 lg:py-16">
+      <div className="max-w-2xl mx-auto px-4">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-lg lg:text-2xl font-bold text-gray-900">
+            리뷰 (20)
+          </h2>
+        </div>
+        <form className="mb-6">
+          <div className="py-2 px-4 mb-4 bg-white rounded-lg rounded-t-lg border border-gray-200">
+            <label className="sr-only">Your comment</label>
+            <textarea
+              id="comment"
+              rows={6}
+              className="px-0 w-full text-sm text-gray-900 border-0 focus:ring-0 focus:outline-none"
+              placeholder="리뷰를 작성해주세요!"
+              required
+            ></textarea>
+          </div>
+          <div className="flex flex-1 justify-end">
+            <button
+              type="submit"
+              className="inline-flex items-center py-2.5 px-4 text-xs font-medium text-center text-white bg-yellow-400 rounded-lg focus:ring-4 focus:ring-yellow-200 hover:bg-yellow-4  00"
+            >
+              리뷰 남기기
+            </button>
+          </div>
+        </form>
+        <article className="p-6 mb-6 text-base bg-white rounded-lg">
+          <footer className="flex justify-between items-center mb-2">
+            <div className="flex items-center">
+              <p className="inline-flex items-center mr-3 text-sm text-gray-900">
+                <img
+                  className="mr-2 w-6 h-6 rounded-full"
+                  src="https://flowbite.com/docs/images/people/profile-picture-2.jpg"
+                  alt="Michael Gough"
+                />
+                Michael Gough
+              </p>
+              <p className="text-sm text-gray-600">
+                <time dateTime="2021-02-14" title="February 8th, 2022">
+                  Feb. 8, 2022
+                </time>
+              </p>
+            </div>
+            <Menu as="div" className="relative inline-block text-left">
+              <div>
+                <Menu.Button className="inline-flex items-center p-2 text-sm font-medium text-center text-gray-400 bg-white rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-50">
+                  <svg
+                    className="w-5 h-5"
+                    aria-hidden="true"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"></path>
+                  </svg>
+                </Menu.Button>
+              </div>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+              >
+                <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                  <div className="px-1 py-1 ">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          className={`${
+                            active
+                              ? "bg-yellow-300 text-white"
+                              : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          {active ? (
+                            <EditActiveIcon
+                              className="mr-2 h-5 w-5"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <EditInactiveIcon
+                              className="mr-2 h-5 w-5"
+                              aria-hidden="true"
+                            />
+                          )}
+                          수정
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </div>
+                  <div className="px-1 py-1">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          className={`${
+                            active
+                              ? "bg-yellow-300 text-white"
+                              : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          {active ? (
+                            <DeleteActiveIcon
+                              className="mr-2 h-5 w-5 text-yellow-400"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <DeleteInactiveIcon
+                              className="mr-2 h-5 w-5 text-yellow-400"
+                              aria-hidden="true"
+                            />
+                          )}
+                          삭제
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </div>
+                </Menu.Items>
+              </Transition>
+            </Menu>
+          </footer>
+          <p className="text-gray-500">
+            Very straight-to-point article. Really worth time reading. Thank
+            you! But tools are just the instruments for the UX designers. The
+            knowledge of the design tools are as important as the creation of
+            the design strategy.
+          </p>
+          <div className="flex items-center mt-4 space-x-4"></div>
+        </article>
+        <article className="p-6 mb-6 text-base bg-white border-t border-gray-200">
+          <footer className="flex justify-between items-center mb-2">
+            <div className="flex items-center">
+              <p className="inline-flex items-center mr-3 text-sm text-gray-900">
+                <img
+                  className="mr-2 w-6 h-6 rounded-full"
+                  src="https://flowbite.com/docs/images/people/profile-picture-3.jpg"
+                  alt="Bonnie Green"
+                />
+                Bonnie Green
+              </p>
+              <p className="text-sm text-gray-600">
+                <time dateTime="2022-03-12" title="March 12th, 2022">
+                  Mar. 12, 2022
+                </time>
+              </p>
+            </div>
+            <button
+              id="dropdownComment3Button"
+              data-dropdown-toggle="dropdownComment3"
+              className="inline-flex items-center p-2 text-sm font-medium text-center text-gray-400 bg-white rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-50"
+              type="button"
+            >
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"></path>
+              </svg>
+              <span className="sr-only">Comment settings</span>
+            </button>
+            <div
+              id="dropdownComment3"
+              className="hidden z-10 w-36 bg-white rounded divide-y divide-gray-100 shadow"
+            >
+              <ul
+                className="py-1 text-sm text-gray-700"
+                aria-labelledby="dropdownMenuIconHorizontalButton"
+              >
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Edit
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Remove
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Report
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </footer>
+          <p className="text-gray-500">
+            The article covers the essentials, challenges, myths and stages the
+            UX designer should consider while creating the design strategy.
+          </p>
+          <div className="flex items-center mt-4 space-x-4">
+            <button
+              type="button"
+              className="flex items-center text-sm text-gray-500 hover:underline"
+            >
+              <svg
+                aria-hidden="true"
+                className="mr-1 w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                ></path>
+              </svg>
+              Reply
+            </button>
+          </div>
+        </article>
+        <article className="p-6 text-base bg-white border-t border-gray-200">
+          <footer className="flex justify-between items-center mb-2">
+            <div className="flex items-center">
+              <p className="inline-flex items-center mr-3 text-sm text-gray-900">
+                <img
+                  className="mr-2 w-6 h-6 rounded-full"
+                  src="https://flowbite.com/docs/images/people/profile-picture-4.jpg"
+                  alt="Helene Engels"
+                />
+                Helene Engels
+              </p>
+              <p className="text-sm text-gray-600">
+                <time dateTime="2022-06-23" title="June 23rd, 2022">
+                  Jun. 23, 2022
+                </time>
+              </p>
+            </div>
+            <button
+              id="dropdownComment4Button"
+              data-dropdown-toggle="dropdownComment4"
+              className="inline-flex items-center p-2 text-sm font-medium text-center text-gray-400 bg-white rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-50"
+              type="button"
+            >
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"></path>
+              </svg>
+            </button>
+            <div
+              id="dropdownComment4"
+              className="hidden z-10 w-36 bg-white rounded divide-y divide-gray-100 shadow"
+            >
+              <ul
+                className="py-1 text-sm text-gray-700"
+                aria-labelledby="dropdownMenuIconHorizontalButton"
+              >
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Edit
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Remove
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="block py-2 px-4 hover:bg-gray-100">
+                    Report
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </footer>
+          <p className="text-gray-500">
+            Thanks for sharing this. I do came from the Backend development and
+            explored some of the tools to design my Side Projects.
+          </p>
+          <div className="flex items-center mt-4 space-x-4">
+            <button
+              type="button"
+              className="flex items-center text-sm text-gray-500 hover:underline"
+            >
+              <svg
+                aria-hidden="true"
+                className="mr-1 w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                ></path>
+              </svg>
+              Reply
+            </button>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}
+function EditInactiveIcon(props: { className: string }) {
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 13V16H7L16 7L13 4L4 13Z"
+        fill="#FFFFFF"
+        stroke="#FDE047"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function EditActiveIcon(props) {
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 13V16H7L16 7L13 4L4 13Z"
+        fill="#8B5CF6"
+        stroke="#C4B5FD"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function DeleteInactiveIcon(props) {
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="5"
+        y="6"
+        width="10"
+        height="10"
+        fill="#FFFFFF"
+        stroke="#FDE047"
+        strokeWidth="2"
+      />
+      <path d="M3 6H17" stroke="#FDE047" strokeWidth="2" />
+      <path d="M8 6V4H12V6" stroke="#FDE047" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function DeleteActiveIcon(props) {
+  return (
+    <svg
+      {...props}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="5"
+        y="6"
+        width="10"
+        height="10"
+        fill="#8B5CF6"
+        stroke="#C4B5FD"
+        strokeWidth="2"
+      />
+      <path d="M3 6H17" stroke="#C4B5FD" strokeWidth="2" />
+      <path d="M8 6V4H12V6" stroke="#C4B5FD" strokeWidth="2" />
+    </svg>
+  );
+}

--- a/src/components/detail/Review.tsx
+++ b/src/components/detail/Review.tsx
@@ -53,7 +53,7 @@ export default function Review() {
                 <Menu.Button className="inline-flex items-center p-2 text-sm font-medium text-center text-gray-400 bg-white rounded-lg hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-50">
                   <svg
                     className="w-5 h-5"
-                    aria-hidden="true"
+                    aria-hidden={true}
                     fill="currentColor"
                     viewBox="0 0 20 20"
                     xmlns="http://www.w3.org/2000/svg"
@@ -85,12 +85,12 @@ export default function Review() {
                           {active ? (
                             <EditActiveIcon
                               className="mr-2 h-5 w-5"
-                              aria-hidden="true"
+                              aria-hidden={true}
                             />
                           ) : (
                             <EditInactiveIcon
                               className="mr-2 h-5 w-5"
-                              aria-hidden="true"
+                              aria-hidden={true}
                             />
                           )}
                           수정
@@ -111,12 +111,12 @@ export default function Review() {
                           {active ? (
                             <DeleteActiveIcon
                               className="mr-2 h-5 w-5 text-yellow-400"
-                              aria-hidden="true"
+                              aria-hidden={true}
                             />
                           ) : (
                             <DeleteInactiveIcon
                               className="mr-2 h-5 w-5 text-yellow-400"
-                              aria-hidden="true"
+                              aria-hidden={true}
                             />
                           )}
                           삭제
@@ -161,7 +161,7 @@ export default function Review() {
             >
               <svg
                 className="w-5 h-5"
-                aria-hidden="true"
+                aria-hidden={true}
                 fill="currentColor"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
@@ -206,7 +206,7 @@ export default function Review() {
               className="flex items-center text-sm text-gray-500 hover:underline"
             >
               <svg
-                aria-hidden="true"
+                aria-hidden={true}
                 className="mr-1 w-4 h-4"
                 fill="none"
                 stroke="currentColor"
@@ -249,7 +249,7 @@ export default function Review() {
             >
               <svg
                 className="w-5 h-5"
-                aria-hidden="true"
+                aria-hidden={true}
                 fill="currentColor"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
@@ -293,7 +293,7 @@ export default function Review() {
               className="flex items-center text-sm text-gray-500 hover:underline"
             >
               <svg
-                aria-hidden="true"
+                aria-hidden={true}
                 className="mr-1 w-4 h-4"
                 fill="none"
                 stroke="currentColor"
@@ -315,7 +315,13 @@ export default function Review() {
     </section>
   );
 }
-function EditInactiveIcon(props: { className: string }) {
+
+type IconProps = {
+  className?: string;
+  "aria-hidden"?: boolean;
+};
+
+function EditInactiveIcon(props: IconProps) {
   return (
     <svg
       {...props}
@@ -333,7 +339,7 @@ function EditInactiveIcon(props: { className: string }) {
   );
 }
 
-function EditActiveIcon(props) {
+function EditActiveIcon(props: IconProps) {
   return (
     <svg
       {...props}
@@ -351,7 +357,7 @@ function EditActiveIcon(props) {
   );
 }
 
-function DeleteInactiveIcon(props) {
+function DeleteInactiveIcon(props: IconProps) {
   return (
     <svg
       {...props}
@@ -374,7 +380,7 @@ function DeleteInactiveIcon(props) {
   );
 }
 
-function DeleteActiveIcon(props) {
+function DeleteActiveIcon(props: IconProps) {
   return (
     <svg
       {...props}

--- a/src/components/detail/Review.tsx
+++ b/src/components/detail/Review.tsx
@@ -343,8 +343,8 @@ function EditActiveIcon(props) {
     >
       <path
         d="M4 13V16H7L16 7L13 4L4 13Z"
-        fill="#8B5CF6"
-        stroke="#C4B5FD"
+        fill="#FDE047"
+        stroke="#FDE047"
         strokeWidth="2"
       />
     </svg>
@@ -387,12 +387,12 @@ function DeleteActiveIcon(props) {
         y="6"
         width="10"
         height="10"
-        fill="#8B5CF6"
-        stroke="#C4B5FD"
+        fill="#FDE047"
+        stroke="#FDE047"
         strokeWidth="2"
       />
-      <path d="M3 6H17" stroke="#C4B5FD" strokeWidth="2" />
-      <path d="M8 6V4H12V6" stroke="#C4B5FD" strokeWidth="2" />
+      <path d="M3 6H17" stroke="#FDE047" strokeWidth="2" />
+      <path d="M8 6V4H12V6" stroke="#FDE047" strokeWidth="2" />
     </svg>
   );
 }

--- a/src/components/information/InformationCard.tsx
+++ b/src/components/information/InformationCard.tsx
@@ -7,7 +7,7 @@ export default function InformationCard({ data, text }: propsType) {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 mt-[3rem]">
         {data?.map((item: any) => (
           <Link href={item.path} key={item.id}>
-            <div className="w-[15rem] sm:w-[25rem] h-[4.1rem] rounded-[10px] bg-amber-200 font-semibold text-lg md:text-2xl flex items-center hover:translate-x-3 ease-in-out duration-300">
+            <div className="w-[15rem] sm:w-[25rem] h-[4.1rem] rounded-[10px] bg-amber-200 font-semibold text-lg md:text-2xl flex items-center lg:hover:translate-x-3 ease-in-out duration-300">
               <text className="ml-[1rem]">{item.name}</text>
             </div>
           </Link>

--- a/src/components/login/LoginFrame.tsx
+++ b/src/components/login/LoginFrame.tsx
@@ -1,10 +1,16 @@
 import Image from "next/image";
 import Link from "next/link";
 import { KAKAO_AUTH_URL, NAVER_AUTH_URL } from "./Oauth";
+import Logo from "../Logo";
 
 export default function LoginFrame() {
   return (
     <main className="w-screen h-screen flex justify-center">
+      <Link href="/">
+        <div className="fixed top-5 left-5">
+          <Logo />
+        </div>
+      </Link>
       <section className="w-[40rem] h-screen bg-amber-200 hidden lg:flex flex-col items-center justify-center">
         <div className="font-extrabold text-3xl leading-loose">
           로그인하고

--- a/src/components/my/MypageFrame.tsx
+++ b/src/components/my/MypageFrame.tsx
@@ -88,7 +88,7 @@ export default function MypageFrame() {
         </button>
       </section>
       <section className="flex flex-col justify-start mt-[2rem] lg:px-[8rem]">
-        <text className="font-bold text-3xl py-[2rem]">나의 활동</text>
+        <div className="font-bold text-3xl py-[2rem]">나의 활동</div>
         <div className="flex flex-col">
           <Tab.Group>
             <Tab.List className="bg-yellowColor flex rounded-xl p-4 border-b-2 border-transparent rounded-t-lg text-lg hover:text-gray-600 hover:border-gray-30">

--- a/src/components/my/MypageFrame.tsx
+++ b/src/components/my/MypageFrame.tsx
@@ -76,7 +76,7 @@ export default function MypageFrame() {
         />
         <div className="font-bold text-2xl lg:text-4xl">{user.name}님</div>
         <div className="text-md lg:text-lg font-bold whitespace-nowrap">
-          {user.socialType === "KAKAO" ? "카카오톡" : "네이버"}으로 로그인 중
+          {user.socialType === "KAKAO" ? "카카오톡" : "네이버"} 로그인 중
         </div>
         <button
           className="w-[6rem] lg:w-[8rem] h-[1.7rem] lg:h-[2rem] font-[500] text-sm lg:text-[1rem] bg-white rounded-xl hover:bg-gray-100"

--- a/src/components/my/MypageFrame.tsx
+++ b/src/components/my/MypageFrame.tsx
@@ -2,7 +2,7 @@
 import { Tab } from "@headlessui/react";
 import { useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import { KakaoTokenAtom, TokenAtom, isLoginSelector } from "@/state";
+import { isLoginSelector, userAtom } from "@/state";
 import { useRouter } from "next/navigation";
 
 function classNames(...classes: string[]) {
@@ -13,7 +13,12 @@ export default function MypageFrame() {
   const router = useRouter();
 
   const isLogin = useRecoilValue(isLoginSelector);
-  const kakaoToken = useSetRecoilState(KakaoTokenAtom);
+  const setUser = useSetRecoilState(userAtom);
+
+  const handleLogout = () => {
+    setUser(null);
+    router.replace("/");
+  };
 
   let [categories] = useState({
     좋아요: [
@@ -51,8 +56,6 @@ export default function MypageFrame() {
     ],
   });
 
-  const setAccessToken = useSetRecoilState(TokenAtom);
-
   if (!isLogin) {
     router.replace("/");
     return <></>;
@@ -68,9 +71,7 @@ export default function MypageFrame() {
         <button
           className="w-[6rem] lg:w-[8rem] h-[1.7rem] lg:h-[2rem] font-[500] text-sm lg:text-[1rem] bg-white rounded-xl hover:bg-gray-100"
           onClick={() => {
-            setAccessToken(undefined);
-            kakaoToken(undefined);
-            router.replace("/");
+            handleLogout();
           }}
         >
           로그아웃

--- a/src/components/my/MypageFrame.tsx
+++ b/src/components/my/MypageFrame.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { Tab } from "@headlessui/react";
 import { useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { isLoginSelector, userAtom } from "@/state";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
@@ -13,7 +14,9 @@ export default function MypageFrame() {
   const router = useRouter();
 
   const isLogin = useRecoilValue(isLoginSelector);
-  const setUser = useSetRecoilState(userAtom);
+  const [user, setUser] = useRecoilState(userAtom);
+
+  console.log(user);
 
   const handleLogout = () => {
     setUser(null);
@@ -64,9 +67,16 @@ export default function MypageFrame() {
   return (
     <main className="flex flex-col w-screen h-screen justify-center p-[2rem] gap-[2rem]">
       <section className="flex flex-col gap-[1rem] justify-start items-center">
-        <div className="font-bold text-2xl lg:text-4xl">000님</div>
+        <Image
+          className="w-[6rem] h-[6rem] rounded-full ring-2 ring-white"
+          src={user.profileImage}
+          alt="profile_img"
+          width={100}
+          height={100}
+        />
+        <div className="font-bold text-2xl lg:text-4xl">{user.name}님</div>
         <div className="text-md lg:text-lg font-bold whitespace-nowrap">
-          카카오톡으로 로그인 중
+          {user.socialType === "KAKAO" ? "카카오톡" : "네이버"}으로 로그인 중
         </div>
         <button
           className="w-[6rem] lg:w-[8rem] h-[1.7rem] lg:h-[2rem] font-[500] text-sm lg:text-[1rem] bg-white rounded-xl hover:bg-gray-100"

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,20 +1,32 @@
 import { atom, selector } from "recoil";
+import { recoilPersist } from "recoil-persist";
 
-export const TokenAtom = atom({
-  key: "TokenAtom",
+const sessionStorage =
+  typeof window !== "undefined" ? window.sessionStorage : undefined;
+
+const { persistAtom: tokenPersistAtom } = recoilPersist({
+  key: "persistAtom",
+  storage: sessionStorage,
+});
+
+export const userAtom = atom({
+  key: "userAtom",
   default: undefined,
+  effects_UNSTABLE: [tokenPersistAtom],
 });
 
 export const isLoginSelector = selector({
   key: "isLoginSelector",
-  get: ({ get }) => {
-    const token = get(TokenAtom);
-    return !!token;
-  },
+  get: ({ get }) => !!get(userAtom),
 });
 
-export const KakaoTokenAtom = atom({
-  key: "KakaoTokenAtom",
+export const kakaoTokenAtom = atom({
+  key: "kakaoTokenAtom",
+  default: undefined,
+});
+
+export const naverTokenAtom = atom({
+  key: "naverTokenAtom",
   default: undefined,
 });
 


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- 네이버 로그인 구현
- 세션스토리지 유저 정보 저장
- 리뷰 탭 구현
- 네이버  프로필 도메인 설정
- swc 적용
- 로그인 페이지 로고 추가
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- 카카오 로그인과 같은 로직으로 네이버 로그인 구현
- recoil-persist를 사용해 sessionStorage에 유저정보 저장 (npm i 필수!)
- 리뷰 탭 UI 및 메뉴 구현
- 빌드 속도 향상을 위해 swc 적용
- 뒤로가기를 위한 로그인 페이지 로고 추가
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [X] 높음
---

### 기타 특이사항
<!-- review시 중요하게 봐야할 내용 또는 특이사항 또는 궁금한점을 작성해주세요-->
<!-- 없으면 없음 기입 -->
- 내용을 입력해주세요
